### PR TITLE
fix: currentUserIdの初期値が空文字だとif文が機能していないので、nullに変更

### DIFF
--- a/pages/javascripts/index.js
+++ b/pages/javascripts/index.js
@@ -10,7 +10,7 @@ export default {
     MainHeader
   },
   data: function() {
-    return {currentUserId: ''};
+    return {currentUserId: null};
   },
   mounted: function() {
     const auth = firebase.auth();


### PR DESCRIPTION
https://github.com/sasurai-usagi3/nippohub-daily/blob/f77b6c2f41aae284cf022549858473e8557c5029/pages/index.vue#L4-L7
にて初期状態では`currentUserId`が`null`であることを期待していたが、空文字にしてしまっていたので修正

認証状態が確定した状態で必要な処理を走らせられる